### PR TITLE
Enforce HTTPS on requests to the backend when not in dev env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 .vscode
 __pycache__/
 *.py[cod]
-node_modules
 */build

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -23,7 +23,9 @@ const api = async (path, payload = {}, explicitBody = false) => {
   }
 
   let response = await fetch(
-    `${process.env.REACT_APP_API || ""}/api/${path}`,
+    `${
+      process.env.REACT_APP_API || `https://${window.location.host}`
+    }/api/${path}`,
     fullPayload
   );
   if (response.status === 401) history.push(paths.signIn);


### PR DESCRIPTION
closes #70 

Essentially the request to the symptoms endpoint for some unknown reason is fired via `http`. The backend logs show no error - I think this is all there's to the issue, but we'll only see for sure once it's deployed!
<img width="794" alt="Screen Shot 2020-06-04 at 10 12 43" src="https://user-images.githubusercontent.com/11891611/83761040-2794a600-a64c-11ea-9d56-7069c9c6857b.png">
