### PR TITLE
#74: Trust proxy headers in live environments

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,6 +1,7 @@
 import os
 
 from fastapi import FastAPI
+from starlette.middleware.httpsredirect import HTTPSRedirectMiddleware
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
@@ -33,5 +34,8 @@ app.add_middleware(
     allow_methods=["DELETE", "GET", "POST", "PUT"],
     allow_headers=["*"],
 )
+
+if not os.environ.get("DEV"):
+    app.add_middleware(HTTPSRedirectMiddleware)
 
 app.include_router(api.router, prefix="/api")

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,7 +1,7 @@
 import os
 
 from fastapi import FastAPI
-from starlette.middleware.httpsredirect import HTTPSRedirectMiddleware
+from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
@@ -35,7 +35,6 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-if not os.environ.get("DEV"):
-    app.add_middleware(HTTPSRedirectMiddleware)
-
 app.include_router(api.router, prefix="/api")
+
+app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")


### PR DESCRIPTION
closes #74 

What a ride

For the record:
* Starlette has [some pretty disturbing issues](https://github.com/encode/starlette/issues/843#issuecomment-629170638) handling requests behind a proxy
* Fortunately, the proxy we're using in Rancher sets all the proper headers, so we hooked up to [Uvicorn's middleware](https://github.com/encode/uvicorn/blob/master/uvicorn/middleware/proxy_headers.py) to ensure requests go out the same way they came in