### PR TITLE
#76: Fix 404 errors to use a custom exception

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,12 +1,14 @@
 import os
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.staticfiles import StaticFiles
+from starlette.responses import JSONResponse
 from starlette.templating import Jinja2Templates
 
 from router import api
+from auth.main import NotFoundException
 
 
 async def homepage(request, exec):
@@ -38,3 +40,10 @@ app.add_middleware(
 app.include_router(api.router, prefix="/api")
 
 app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
+
+
+@app.exception_handler(NotFoundException)
+async def not_found_exception_handler(
+    request: Request, exc: NotFoundException
+):
+    return JSONResponse(status_code=404, content={"message": exc.message},)

--- a/backend/app.py
+++ b/backend/app.py
@@ -46,4 +46,4 @@ app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
 async def not_found_exception_handler(
     request: Request, exc: NotFoundException
 ):
-    return JSONResponse(status_code=404, content={"message": exc.message},)
+    return JSONResponse(status_code=404, content={"detail": exc.message},)

--- a/backend/auth/main.py
+++ b/backend/auth/main.py
@@ -17,6 +17,11 @@ from stories.crud import get_story
 from . import schemas
 
 
+class NotFoundException(Exception):
+    def __init__(self, message: str):
+        self.message = message
+
+
 class OAuth2PasswordBearerCookie(OAuth2):
     def __init__(
         self,
@@ -155,7 +160,7 @@ async def get_current_story(
         )
     if not story:
         if not (user and user.story):  # no story nor user match the token data
-            raise HTTPException(status_code=404, detail="Story not found")
+            raise NotFoundException(message="Story not found")
         else:  # there's a user with a story
             return user.story
     if not user:


### PR DESCRIPTION
closes #76 

Basically, we need to have custom 404 exceptions due to the override done to support the frontend builds.

As a footnote, I tried having the exception live in `app.py` and importing it in the `auth.main` method where we need it right now and couldn't get it to work.