### PR TITLE
Do not disable worldLayer based on maxZoom

### DIFF
--- a/frontend/src/components/Map/index.js
+++ b/frontend/src/components/Map/index.js
@@ -61,7 +61,6 @@ async function addWorldLayer(map, data) {
       id: "maine",
       type: "fill",
       layout: {},
-      maxzoom: countryMinZoom,
       paint: {
         "fill-color": {
           type: "categorical",
@@ -168,11 +167,11 @@ async function addUSStatesLayer(map, data) {
       type: "fill",
       source: "states",
       minzoom: countryMinZoom,
-      // maxzoom: statesMinZoom,
       "source-layer": "states",
       paint: {
         "fill-color": expression,
         "fill-outline-color": fillOutlineColor,
+        "fill-opacity": 1,
       },
     },
     "waterway-label"


### PR DESCRIPTION
US-States-layer displays on-top on world-layer

The superposition of the layers is notable on the edges of US country. This is happening (for what I understand) because the tilesets that each layer uses differ on the boundaries by a little
For the moment, with what we have, is the best we can accomplish 