### PR TITLE
remove myTrials/myDonations/myRecords

### DIFF
--- a/frontend/src/routes/Dashboard/index.js
+++ b/frontend/src/routes/Dashboard/index.js
@@ -65,11 +65,7 @@ function Dashboard(props) {
         status.detail
       ) : (
         <>
-          <Breadcrumbs aria-label="breadcrumb" className={styles.breadcrumbs}>
-            <Link color="inherit">myTrials</Link>
-            <Link color="inherit">myDonations</Link>
-            <Link color="inherit">myRecords</Link>
-          </Breadcrumbs>
+          <Breadcrumbs aria-label="breadcrumb" className={styles.breadcrumbs} />
           <div className={classNames(styles.box, styles.top, styles.left)}>
             <h3>MY STATUS</h3>
             <div className="status-list">


### PR DESCRIPTION
Left the `Breadcrumbs` since if not in device-mode looked weird

## without breadcrumbs
![image](https://user-images.githubusercontent.com/13237343/84547666-683e9000-acda-11ea-9e2c-41499b9f1a38.png)

## with breadcrumbs
![image](https://user-images.githubusercontent.com/13237343/84547788-9cb24c00-acda-11ea-8676-d1eb3ddad079.png)

I'm sure there is a better way for accomplishing this without the breadcrumbs.. but I'm not very skilled with css, and this get the thing done


closes #54 