### PR TITLE
Add /api/data/all

### DIFF
--- a/backend/router/data.py
+++ b/backend/router/data.py
@@ -102,15 +102,13 @@ def get_all_data():
         },
     )
 
-    groupped_data = functools.reduce(
-        group_by_scope, clustered_data["data"], {}
+    grouped_data = functools.reduce(group_by_scope, clustered_data["data"], {})
+
+    grouped_data[DataScope.ADM1] = group_by_parent(
+        grouped_data[DataScope.ADM1]
     )
 
-    groupped_data[DataScope.ADM1] = group_by_parent(
-        groupped_data[DataScope.ADM1]
-    )
-
-    return {"data": groupped_data, "clusters": clustered_data["clusters"]}
+    return {"data": grouped_data, "clusters": clustered_data["clusters"]}
 
 
 def group_by_scope(base, entry):


### PR DESCRIPTION
# Solution
* Add new api with all the available data
* All the data is being clustered together using Jenks with 10 bins
* The second approach 
> If not, split the dataset in two, and run jenks on each half with four bins. Use the max-cases-state as the splitting point

was tried but it didn't result for the current data: NY state had more cases that almost all countries 

# API structure: 🏗️ 
 * changed it to make it extensible for future `adm1` data
Being:
```python
ADM0 = "adm0"  # Base administrative area (countries)
ADM1 = "adm1"  # First level administrative area (states/provinces)
```

* Clusters intervals are returned under `clusters` key in response

![image](https://user-images.githubusercontent.com/13237343/84556232-6f27cb80-acf7-11ea-85b4-c99537b754c5.png)

closes #98 

