### PR TITLE
Add map legend

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,4 @@ python-multipart
 requests
 pandas
 jenkspy
+sigfig

--- a/backend/router/data.py
+++ b/backend/router/data.py
@@ -93,13 +93,11 @@ def get_covid_us_states_data():
 def get_all_data():
     countries = fetch_world_data()
     us_states = fetch_us_states_data()
+    cluster_labels = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]
 
     clustered_data = cluster_data(
         countries + us_states,
-        clusters_config={
-            "clusters": 10,
-            "labels": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1],
-        },
+        clusters_config={"clusters": 10, "labels": cluster_labels},
     )
 
     grouped_data = functools.reduce(group_by_scope, clustered_data["data"], {})
@@ -108,7 +106,11 @@ def get_all_data():
         grouped_data[DataScope.ADM1]
     )
 
-    return {"data": grouped_data, "clusters": clustered_data["clusters"]}
+    return {
+        "data": grouped_data,
+        "clusters": clustered_data["clusters"],
+        "groups": cluster_labels,
+    }
 
 
 def group_by_scope(base, entry):

--- a/backend/router/data.py
+++ b/backend/router/data.py
@@ -69,7 +69,7 @@ def cluster_data(confirmed, clusters_config=None):
 
     df["group"] = pd.cut(
         df["confirmed"],
-        bins=rounded_breaks,
+        bins=breaks,
         labels=clusters_config["labels"],
         include_lowest=True,
     )

--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -7,7 +7,6 @@ pre-commit install -f
 
 # lift & update containers
 docker-compose build
-docker-compose up db
 docker-compose run --rm api pip install -r requirements.txt
 docker-compose run --rm api pip install -r requirements.dev.txt
 docker-compose run --rm api python init_db.py

--- a/frontend/src/components/Map/index.js
+++ b/frontend/src/components/Map/index.js
@@ -233,14 +233,12 @@ export default function Map({ draggable = true }) {
   const legend = (
     <div className={classNames(styles.legend)} id="legend">
       <h4>Active cases</h4>
-      {legendRanges.map((range, i) => {
-        return (
-          <div className={classNames(styles.legendItem)} key={i}>
-            <span style={{ backgroundColor: range.color }}></span>
-            {range.label}
-          </div>
-        );
-      })}
+      {legendRanges.map((range, i) => (
+        <div className={classNames(styles.legendItem)} key={i}>
+          <span style={{ backgroundColor: range.color }}></span>
+          {range.label}
+        </div>
+      ))}
     </div>
   );
 

--- a/frontend/src/components/Map/index.js
+++ b/frontend/src/components/Map/index.js
@@ -59,7 +59,7 @@ export default function Map({ draggable = true }) {
       clusters &&
       clusters.map((range, i) => {
         return {
-          label: range[1],
+          label: `${range[0].toLocaleString()} - ${range[1].toLocaleString()}`,
           color: getColor(colorGroups[i]),
         };
       });
@@ -237,7 +237,7 @@ export default function Map({ draggable = true }) {
         return (
           <div className={classNames(styles.legendItem)} key={i}>
             <span style={{ backgroundColor: range.color }}></span>
-            {range.label.toLocaleString()}
+            {range.label}
           </div>
         );
       })}

--- a/frontend/src/components/Map/index.js
+++ b/frontend/src/components/Map/index.js
@@ -24,6 +24,7 @@ export default function Map({ draggable = true }) {
     lng: -119.6,
     lat: 36.7,
   });
+  const [legendRanges, setLegendRanges] = useState([]);
 
   useEffect(() => {
     getUserLocation();
@@ -51,6 +52,19 @@ export default function Map({ draggable = true }) {
       });
   }, [location, map]);
 
+  const addLegend = (data) => {
+    const clusters = data.clusters;
+    const colorGroups = data.groups;
+    const newRanges =
+      clusters &&
+      clusters.map((range, i) => {
+        return {
+          label: range[1],
+          color: getColor(colorGroups[i]),
+        };
+      });
+    newRanges && setLegendRanges(newRanges);
+  };
   const getUserLocation = async () => {
     const userLocation = await fetchUserLocation();
     if (userLocation) {
@@ -64,8 +78,10 @@ export default function Map({ draggable = true }) {
 
   const addLayers = async (map) => {
     const data = await fetchCovidData(dataScope.ALL);
-    const worldData = data["adm0"];
-    const usStatesData = data["adm1"]["US"];
+    const worldData = data["data"]["adm0"];
+    const usStatesData = data["data"]["adm1"]["US"];
+
+    addLegend(data);
 
     map.on("load", function () {
       addWorldLayer(map, worldData);
@@ -85,7 +101,7 @@ export default function Map({ draggable = true }) {
     const body = await api(`data/${scope}`, {
       method: "GET",
     });
-    return body["data"];
+    return body;
   };
 
   const getColor = (group) => {
@@ -214,10 +230,30 @@ export default function Map({ draggable = true }) {
     );
   };
 
+  const legend = (
+    <div className={classNames(styles.legend)} id="legend">
+      <h4>Active cases</h4>
+      {legendRanges.map((range, i) => {
+        return (
+          <div className={classNames(styles.legendItem)} key={i}>
+            <span style={{ backgroundColor: range.color }}></span>
+            {range.label.toLocaleString()}
+          </div>
+        );
+      })}
+    </div>
+  );
+
+  const draggableDependantFeatures = () => {
+    if (draggable) {
+      return legendRanges.length !== 0 ? legend : null;
+    }
+    return <div className={classNames(styles.fill, styles.mask)} />;
+  };
   return (
     <div className={styles.root}>
       <div className={classNames(styles.fill)} id="map"></div>
-      {!draggable && <div className={classNames(styles.fill, styles.mask)} />}
+      {draggableDependantFeatures()}
     </div>
   );
 }

--- a/frontend/src/components/Map/styles.module.css
+++ b/frontend/src/components/Map/styles.module.css
@@ -25,7 +25,8 @@
   border-radius: 3px;
   bottom: 30px;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
-  font: 12px/20px "Helvetica Neue", Arial, Helvetica, sans-serif;
+  font-size: 12px;
+  line-height: 20px;
   padding: 10px;
   position: absolute;
   left: 10px;
@@ -35,7 +36,7 @@
 }
 
 .legend h4 {
-  margin: 0 0 10px;
+  margin: 0 0 5px;
   color: whitesmoke;
 }
 

--- a/frontend/src/components/Map/styles.module.css
+++ b/frontend/src/components/Map/styles.module.css
@@ -28,7 +28,7 @@
   font: 12px/20px "Helvetica Neue", Arial, Helvetica, sans-serif;
   padding: 10px;
   position: absolute;
-  right: 10px;
+  left: 10px;
   z-index: 2;
   display: block;
   text-align: left;

--- a/frontend/src/components/Map/styles.module.css
+++ b/frontend/src/components/Map/styles.module.css
@@ -20,3 +20,33 @@
 .map {
   z-index: 1;
 }
+.legend {
+  background-color: rgba(153, 149, 149, 0.6);
+  border-radius: 3px;
+  bottom: 30px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  font: 12px/20px "Helvetica Neue", Arial, Helvetica, sans-serif;
+  padding: 10px;
+  position: absolute;
+  right: 10px;
+  z-index: 2;
+  display: block;
+  text-align: left;
+}
+
+.legend h4 {
+  margin: 0 0 10px;
+  color: whitesmoke;
+}
+
+.legend div span {
+  border-radius: 50%;
+  display: inline-block;
+  height: 10px;
+  margin-right: 5px;
+  width: 10px;
+}
+
+.legendItem{
+  color: whitesmoke;
+}

--- a/frontend/src/css/index.css
+++ b/frontend/src/css/index.css
@@ -97,11 +97,6 @@ a, a:link, a:visited, a:hover, a:active {
   left: 5%
 }
 
-.status-item {
-  align-items: center;
-  margin-bottom: 10px;
-}
-
 .terms-wrapper {
   overflow-y: scroll;
   padding: 1rem 2rem;

--- a/frontend/src/routes/Dashboard/index.js
+++ b/frontend/src/routes/Dashboard/index.js
@@ -1,4 +1,3 @@
-import Breadcrumbs from "@material-ui/core/Breadcrumbs";
 import Link from "@material-ui/core/Link";
 import SpeedDial from "@material-ui/lab/SpeedDial";
 import SpeedDialAction from "@material-ui/lab/SpeedDialAction";
@@ -59,61 +58,68 @@ function Dashboard(props) {
       .then((result) => setData(result));
   }, []);
 
+  const userStatus = () => (
+    <div className={classNames(styles.statusList)}>
+      <div className={classNames("row", styles.statusItem)}>
+        <span
+          className={styles.dot}
+          style={{ background: statusMapping[story.sick].color }}
+        />
+        {statusMapping[story.sick].name.toUpperCase()}
+      </div>
+      <div className={classNames("row", styles.statusItem)}>
+        <span
+          className={styles.dot}
+          style={{ background: statusMapping[story.tested].color }}
+        />
+        {statusMapping[story.tested].name.toUpperCase()}
+      </div>
+      <div></div>
+    </div>
+  );
+
+  const latestUpdate = () => (
+    <div>
+      <h3>LATEST TOTALS</h3>
+      <div className="row">
+        <div className={classNames(styles.totalItem)}>
+          Actives: {data.confirmed && data.confirmed.toLocaleString()}
+        </div>
+        <div className={classNames(styles.totalItem)}>
+          Deaths: {data.deaths && data.deaths.toLocaleString()}
+        </div>
+        <div className={classNames(styles.totalItem)}>
+          Recovered: {data.recovered && data.recovered.toLocaleString()}
+        </div>
+      </div>
+    </div>
+  );
+
+  const suggestions = () => (
+    <div className={classNames(styles.box, styles.top, styles.header)}>
+      <h3>SUGGESTIONS</h3>
+      <div>Stay at home</div>
+      {getStorySuggestions(story).map((suggestion) => (
+        <Link
+          href={suggestion.site}
+          {...(suggestion.color ? { style: { color: suggestion.color } } : {})}
+          target="_blank"
+        >
+          {suggestion.text}
+        </Link>
+      ))}
+      {userStatus()}
+      {latestUpdate()}
+    </div>
+  );
+
   return (
     <div className={styles.root}>
       {status.type === LOADING || !story ? (
         status.detail
       ) : (
         <>
-          <div className={classNames(styles.box, styles.top, styles.left)}>
-            <div className="status-list">
-              <div className="row status-item">
-                <span
-                  className={styles.dot}
-                  style={{ background: statusMapping[story.sick].color }}
-                />
-                {statusMapping[story.sick].name}
-              </div>
-              <div className="row status-item">
-                <span
-                  className={styles.dot}
-                  style={{ background: statusMapping[story.tested].color }}
-                />
-                {statusMapping[story.tested].name}
-              </div>
-              <div></div>
-            </div>
-          </div>
-          <div className={classNames(styles.box, styles.top, styles.right)}>
-            <h3>LATEST UPDATE</h3>
-            <div>
-              <div>COVID-19 Cases: {data.confirmed}</div>
-              <div>Total Deaths: {data.deaths}</div>
-              <div>Total Recovered: {data.recovered}</div>
-            </div>
-          </div>
-          <div
-            className={classNames(
-              styles.box,
-              styles.bottom,
-              styles.left,
-              styles.wrapper
-            )}
-          >
-            <h3>SUGGESTIONS</h3>
-            <div>Stay at home</div>
-            {getStorySuggestions(story).map((suggestion) => (
-              <Link
-                href={suggestion.site}
-                {...(suggestion.color
-                  ? { style: { color: suggestion.color } }
-                  : {})}
-                target="_blank"
-              >
-                {suggestion.text}
-              </Link>
-            ))}
-          </div>
+          {suggestions()}
           <SpeedDial
             ariaLabel="Daily actions"
             className={classNames("speeddial", styles.speeddial)}

--- a/frontend/src/routes/Dashboard/index.js
+++ b/frontend/src/routes/Dashboard/index.js
@@ -83,13 +83,22 @@ function Dashboard(props) {
       <h3>LATEST TOTALS</h3>
       <div className="row">
         <div className={classNames(styles.totalItem)}>
-          Actives: {data.confirmed && data.confirmed.toLocaleString()}
+          ACTIVES
+          <div className={classNames(styles.totalItemNum)}>
+            {data.confirmed && data.confirmed.toLocaleString()}
+          </div>
         </div>
         <div className={classNames(styles.totalItem)}>
-          Deaths: {data.deaths && data.deaths.toLocaleString()}
+          DEATHS
+          <div className={classNames(styles.totalItemNum)}>
+            {data.deaths && data.deaths.toLocaleString()}
+          </div>
         </div>
         <div className={classNames(styles.totalItem)}>
-          Recovered: {data.recovered && data.recovered.toLocaleString()}
+          RECOVERED
+          <div className={classNames(styles.totalItemNum)}>
+            {data.recovered && data.recovered.toLocaleString()}
+          </div>
         </div>
       </div>
     </div>

--- a/frontend/src/routes/Dashboard/index.js
+++ b/frontend/src/routes/Dashboard/index.js
@@ -79,7 +79,7 @@ function Dashboard(props) {
   );
 
   const latestUpdate = () => (
-    <div>
+    <>
       <h3>LATEST TOTALS</h3>
       <div className="row">
         <div className={classNames(styles.totalItem)}>
@@ -101,13 +101,13 @@ function Dashboard(props) {
           </div>
         </div>
       </div>
-    </div>
+    </>
   );
 
   const suggestions = () => (
-    <div>
+    <>
       <h3>SUGGESTIONS</h3>
-      <div>Stay at home</div>
+      <p>Stay at home</p>
       {getStorySuggestions(story).map((suggestion) => (
         <Link
           href={suggestion.site}
@@ -117,7 +117,7 @@ function Dashboard(props) {
           {suggestion.text}
         </Link>
       ))}
-    </div>
+    </>
   );
 
   const informationHeader = () => (

--- a/frontend/src/routes/Dashboard/index.js
+++ b/frontend/src/routes/Dashboard/index.js
@@ -65,9 +65,7 @@ function Dashboard(props) {
         status.detail
       ) : (
         <>
-          <Breadcrumbs aria-label="breadcrumb" className={styles.breadcrumbs} />
           <div className={classNames(styles.box, styles.top, styles.left)}>
-            <h3>MY STATUS</h3>
             <div className="status-list">
               <div className="row status-item">
                 <span

--- a/frontend/src/routes/Dashboard/index.js
+++ b/frontend/src/routes/Dashboard/index.js
@@ -105,7 +105,7 @@ function Dashboard(props) {
   );
 
   const suggestions = () => (
-    <div className={classNames(styles.box, styles.top, styles.header)}>
+    <div>
       <h3>SUGGESTIONS</h3>
       <div>Stay at home</div>
       {getStorySuggestions(story).map((suggestion) => (
@@ -117,6 +117,12 @@ function Dashboard(props) {
           {suggestion.text}
         </Link>
       ))}
+    </div>
+  );
+
+  const informationHeader = () => (
+    <div className={classNames(styles.box, styles.top, styles.header)}>
+      {suggestions()}
       {userStatus()}
       {latestUpdate()}
     </div>
@@ -128,7 +134,7 @@ function Dashboard(props) {
         status.detail
       ) : (
         <>
-          {suggestions()}
+          {informationHeader()}
           <SpeedDial
             ariaLabel="Daily actions"
             className={classNames("speeddial", styles.speeddial)}

--- a/frontend/src/routes/Dashboard/styles.module.css
+++ b/frontend/src/routes/Dashboard/styles.module.css
@@ -5,6 +5,8 @@
     height: 100%;
 }
 
+.root p{ margin: 0; }
+
 .assessment {
     color:white !important;
     background-color: var(--primary) !important;
@@ -77,7 +79,7 @@
 }
 
 .header h3{
-    margin-block-end: 0.5em;
+    margin-bottom: 0.2rem;
 }
 
 .statusList {

--- a/frontend/src/routes/Dashboard/styles.module.css
+++ b/frontend/src/routes/Dashboard/styles.module.css
@@ -96,8 +96,12 @@
     display: inline-flex;
 }
 
+.totalItemNum {
+    font-size: 1rem;
+}
 .totalItem {
     margin-right: 15px;
+    font-size: 0.8rem;
 }
 
 @media (max-width: 1024px) {

--- a/frontend/src/routes/Dashboard/styles.module.css
+++ b/frontend/src/routes/Dashboard/styles.module.css
@@ -5,19 +5,6 @@
     height: 100%;
 }
 
-.breadcrumbs {
-    position: absolute;
-    right: 5%;
-    top: 28px;
-    justify-content: flex-end;
-    display: flex;
-    align-items: center;
-}
-.breadcrumbs * {
-    color: white;
-    font-family: Abel;
-}
-
 .assessment {
     color:white !important;
     background-color: var(--primary) !important;
@@ -90,20 +77,12 @@
     .right { right: 0; left: 50%;}
     .wrapper { right: 0; }
     .top {
-        top: 4rem;
+        top: 0rem;
         min-height: 150px;
-        padding-top: 0;
+        padding-top: 4rem;
     }
     .bottom { bottom: 0; }
     .box {
         border-radius: 0;
-    }
-    .breadcrumbs {
-        top: 0;
-        left: 0;
-        right: 0;
-        height: 4rem;
-        background-color: rgba(0,0,0, 0.5);
-        padding: 0 1rem;
     }
 }

--- a/frontend/src/routes/Dashboard/styles.module.css
+++ b/frontend/src/routes/Dashboard/styles.module.css
@@ -23,12 +23,12 @@
 }
 
 .dot {
-  height: 25px;
-  width: 25px;
+  height: 1em;
+  width: 1em;
   background-color: #bbb;
   border-radius: 50%;
   display: inline-block;
-  margin-right: 10px;
+  margin-right: 5px;
 }
 
 .box {
@@ -55,8 +55,7 @@
 
 .box h3 { margin-top: 0; }
 
-.top { top: 5rem; }
-
+.top { top: 1rem; }
 
 .left {
     left: 3rem;
@@ -72,6 +71,35 @@
     bottom: 2rem;
 }
 
+.header {
+    text-align: left;
+    right: 3rem;
+}
+
+.header h3{
+    margin-block-end: 0.5em;
+}
+
+.statusList {
+    margin-top: 10px;
+    text-align: center;
+}
+
+.statusItem {
+    align-items: center;
+    margin-bottom: 10px;
+    display: inline-flex;
+    margin-right: 20px;
+}
+
+.latestTotals {
+    display: inline-flex;
+}
+
+.totalItem {
+    margin-right: 15px;
+}
+
 @media (max-width: 1024px) {
     .left { left: 0; right: 50%; }
     .right { right: 0; left: 50%;}
@@ -84,5 +112,10 @@
     .bottom { bottom: 0; }
     .box {
         border-radius: 0;
+    }
+    .header{
+        width: 100%;
+        text-align: left;
+        left: 0rem;
     }
 }


### PR DESCRIPTION
# Map legend 🗺️ 
* All the data is now being clustered in 5 groups
* values are rounded to the three-most-significant digit
* values are only rounded in the legend
Rounded breaks are not used for clustering the data, since it can happen that the rounded upper limit `<` some regions cases. If this happens, it would end in those regions not being member of any cluster.
For example, if a region has `2,163,543` active cases, the rounded limit would be `2,160,000`. Thus, if clustering with such upper-limit would end with such region out of the cluster

# UI tweaks 🔩 
For showing the legend alongside all the data that was already being displayed without having overlapping, some rearrangements where needed: 
 * New wording `latest totals`
 * New wording `actives`
 * New layout for showing `latestUpdate`
 * Smaller status dot size 🔴
 * Add `toLocaleString()` to numbers (#100)
 * Rearrange of `suggestions`, `latestUpdate` and `userStatus` order
## Mobile 
<img src="https://user-images.githubusercontent.com/13237343/85037010-32c2f800-b15b-11ea-928a-fac73f668faa.png" width="50%" height="50%">

## Desktop
<img src="https://user-images.githubusercontent.com/13237343/85036892-10c97580-b15b-11ea-9331-371fe77a57d8.png" width="75%" height="75%">

# Bonus ➕ 

* remove unnecessary `docker-compose up db` from `dev-setup.sh`


closes #94 