### PR TITLE
Add 'I prefer not to state' option in Ethnicity select

### DIFF
--- a/frontend/src/routes/CriticalQuestions/index.js
+++ b/frontend/src/routes/CriticalQuestions/index.js
@@ -222,7 +222,7 @@ function CriticalQuestions(props) {
             <MenuItem value={"male"}>Male</MenuItem>
             <MenuItem value={"female"}>Female</MenuItem>
             <MenuItem value={"other"}>Other</MenuItem>
-            <MenuItem value={null}>I don't want to answer</MenuItem>
+            <MenuItem value={null}>I prefer not to state</MenuItem>
           </TextField>
 
           <TextField

--- a/frontend/src/routes/CriticalQuestions/index.js
+++ b/frontend/src/routes/CriticalQuestions/index.js
@@ -49,6 +49,7 @@ const ethnicGroups = [
     label: "Native Hawaiian or Other Pacific Islander",
   },
   { value: "White", label: "White" },
+  { value: null, label: "I prefer not to state" },
 ];
 
 function CriticalQuestions(props) {


### PR DESCRIPTION
Added the option following the example of  `Sex` field

This solution behaves oddly since when you select this new option the field doesn't show the text `'I prefer not to state'`. The same thing happens with `Sex` field

@pyritewolf  I tried but failed to make this happen (not having a good day with front today 😠 😞 ) without falling to solutions that seems ugly-and-dirty to me

On other thoughts, should we change the `Sex` field option to this same string to keep it consistent? (Instead of `'I don't want to answer'`)

closes #118 
