### PR TITLE
Fix travel state

### DIFF
--- a/backend/router/stories.py
+++ b/backend/router/stories.py
@@ -5,6 +5,7 @@ from fastapi import Depends, APIRouter, HTTPException, status
 from sqlalchemy.orm import Session
 from starlette.responses import JSONResponse
 from starlette.requests import Request
+from fastapi.encoders import jsonable_encoder
 
 from database import get_db
 from auth import main
@@ -44,10 +45,10 @@ async def create_story(
     else:
         db_story = crud.create_story(db=db, story=story, user=user)
 
+    jsonStory = jsonable_encoder(schemas.Story.from_orm(db_story))
+
     # prepare response
-    response = JSONResponse(
-        schemas.Story.from_orm(db_story).dict(), status_code=200
-    )
+    response = JSONResponse(jsonStory, status_code=200)
     if not token_data:
         access_token = main.create_access_token(data={"story_id": db_story.id})
         response.set_cookie(

--- a/backend/stories/crud.py
+++ b/backend/stories/crud.py
@@ -13,6 +13,7 @@ def update(model_id: int, dto: schemas.BaseModel, model: Base, db: Session):
     for k, v in item_as_dict.items():
         setattr(db_item, k, v)
     db.commit()
+    db.refresh(db_item)
     return db_item
 
 

--- a/backend/stories/models.py
+++ b/backend/stories/models.py
@@ -23,7 +23,7 @@ class Story(Base):
     current_location = Column(String(128))
     user = relationship("User", uselist=False, back_populates="story")
     symptoms = relationship("Symptom", secondary="story_symptoms")
-    travels = relationship("Travel", lazy="noload")
+    travels = relationship("Travel", lazy="select")
 
     @property
     def medical_conditions(self):

--- a/frontend/src/actions/story.js
+++ b/frontend/src/actions/story.js
@@ -53,7 +53,8 @@ export const submitStory = (dto) => async (dispatch) => {
   });
 
   if (!response.error) {
-    if (travels.length) dispatch(submitTravels(travels, response.id, nextPage));
+    if (travels.length)
+      dispatch(submitTravels(travels, story, response.id, nextPage));
     else history.push(nextPage);
   }
 };
@@ -78,22 +79,20 @@ export const fetchStory = () => async (dispatch) => {
 
 export const getCurrentStory = async (dispatch) => {
   dispatch({ type: FETCH_STORY_START });
-  const { error, travels, ...story } = await api("stories/");
+  const { error, ...story } = await api("stories/");
   dispatch({
     type: FETCH_STORY,
     payload: {
       status: error || { type: SUCCESS },
       story: (!error && story) || null,
-      travels:
-        (!error &&
-          travels.map((travel) => parseObjectKeys(travel, snakeToCamelCase))) ||
-        [],
     },
   });
   return story;
 };
 
-const submitTravels = (travels, storyId, nextPage) => async (dispatch) => {
+const submitTravels = (travels, story, storyId, nextPage) => async (
+  dispatch
+) => {
   dispatch({ type: SUBMIT_TRAVELS_START });
   let parsedTravels = travels.map((travel) => ({ ...travel, storyId }));
   const newTravels = parsedTravels.filter((travel) => !("id" in travel));
@@ -117,7 +116,7 @@ const submitTravels = (travels, storyId, nextPage) => async (dispatch) => {
     type: SUBMIT_TRAVELS,
     payload: {
       status: errors || { type: SUCCESS },
-      travels: (!errors && responseTravels) || null,
+      story: { ...story, travels: (!errors && responseTravels) || [] },
     },
   });
 

--- a/frontend/src/actions/story.js
+++ b/frontend/src/actions/story.js
@@ -79,7 +79,6 @@ export const fetchStory = () => async (dispatch) => {
 export const getCurrentStory = async (dispatch) => {
   dispatch({ type: FETCH_STORY_START });
   const { error, travels, ...story } = await api("stories/");
-
   dispatch({
     type: FETCH_STORY,
     payload: {
@@ -99,19 +98,21 @@ const submitTravels = (travels, storyId, nextPage) => async (dispatch) => {
   let parsedTravels = travels.map((travel) => ({ ...travel, storyId }));
   const newTravels = parsedTravels.filter((travel) => !("id" in travel));
   const updatedTravels = parsedTravels.filter((travel) => "id" in travel);
-  const postResponse = await api(`stories/${storyId}/travels`, {
-    method: "POST",
-    body: newTravels,
-  });
-  const putResponse = await api(`stories/${storyId}/travels`, {
-    method: "PUT",
-    body: updatedTravels,
-  });
+  const postResponse =
+    newTravels.length &&
+    (await api(`stories/${storyId}/travels`, {
+      method: "POST",
+      body: newTravels,
+    }));
+  const putResponse =
+    updatedTravels.length &&
+    (await api(`stories/${storyId}/travels`, {
+      method: "PUT",
+      body: updatedTravels,
+    }));
 
   const errors = postResponse.error || putResponse.error;
-  const responseTravels = (postResponse.travels || []).concat(
-    putResponse.travels || []
-  );
+  const responseTravels = (postResponse || []).concat(putResponse || []);
   dispatch({
     type: SUBMIT_TRAVELS,
     payload: {

--- a/frontend/src/reducers/story.js
+++ b/frontend/src/reducers/story.js
@@ -14,7 +14,6 @@ import {
 const initialState = {
   status: {},
   story: null,
-  travels: [],
 };
 
 const story = (state = initialState, action) => {

--- a/frontend/src/routes/CriticalQuestions/index.js
+++ b/frontend/src/routes/CriticalQuestions/index.js
@@ -59,17 +59,17 @@ function CriticalQuestions(props) {
   const [recentTravels, setRecentTravels] = useState([]);
 
   let nextPage;
-  const { story, status, travels } = useSelector((state) => state.story);
+  const { story, status } = useSelector((state) => state.story);
 
   useEffect(() => {
     if (!story) {
       dispatch(fetchStory());
     } else {
       setFormValues({ ...formValues, ...story });
-      setRecentTravels(travels);
+      setRecentTravels(story.travels);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dispatch, story, travels]);
+  }, [dispatch, story]);
 
   const handleFormChange = (field) => (event) => {
     const intFields = [fields.AGE];

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -52,7 +52,13 @@ const api = async (path, payload = {}, explicitBody = false) => {
 
 export const parseObjectKeys = (object, method) =>
   Object.keys(object).reduce((acc, key) => {
-    acc[method(key)] = object[key];
+    if (Array.isArray(object[key])) {
+      acc[method(key)] = object[key].map((element) =>
+        parseObjectKeys(element, snakeToCamelCase)
+      );
+    } else {
+      acc[method(key)] = object[key];
+    }
     return acc;
   }, {});
 


### PR DESCRIPTION
There were a few problems, some co-related.
I list them here so that the modifications in the code make sense 🙂 

 * Travels where not being stored in reducer state since the response does not include a `travels` field, its directly a list with the travels
 * When a user is registered, when it authenticates the sites redirects to the `Dashboard`. When this happens, the travels where not being saved in the store since the code was assuming the `travels` where being returned in the response when it didn't (due to the `lazy="noload"`)
 * When I changed backend code so that the `travels` where returned in the `read_story` request, the api was breaking since an encoder was not being used (and thus the dates could not be serialized)
 * The POST & PUT of travels to the backend were being done even if  there was nothing to create or update  
 * Since now the stories response includes the travels, there where two travels: the `story.travels` and the `travels` in the story reducer -> decided to unify them since having two places where the data is present is a trouble for updating and accessing, and thus, to prevent some piece of code accessing stale data

Bonus: modified the `utils.js:parseObjectKeys` so that if there is a field that's an array it serializes all the elements inside 

closes #128 