### PR TITLE
fix frontend/utils:parseObjectKeys

### DIFF
--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -54,7 +54,9 @@ export const parseObjectKeys = (object, method) =>
   Object.keys(object).reduce((acc, key) => {
     if (Array.isArray(object[key])) {
       acc[method(key)] = object[key].map((element) =>
-        parseObjectKeys(element, snakeToCamelCase)
+        typeof element === "object" && element !== null
+          ? parseObjectKeys(element, method)
+          : element
       );
     } else {
       acc[method(key)] = object[key];


### PR DESCRIPTION
Application was showing a black screen because the submission of story with medical conditions was failing. 
The frontend was serializing badly the medical conditions