### PR TITLE
bug/148 added alembic env to flake8 ignore list

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,8 +14,9 @@ repos:
         exclude: >
             (?x)^(
                 legacy/|
-                backend/emails/contents.py
-            )$ 
+                backend/emails/contents.py|
+                backend/alembic/env.py
+            )$
         language_version: python3.7
     # tried to to all the precommit work here, didn't work.
     # Leaving it as something we might want to look into


### PR DESCRIPTION
This pull request addresses #148 in which new models need to be imported (but never explicitly used from written code) in the Alembic `env.py` but flake8 rejects the commit because the imports aren't used. Here I've just added the `env.py` file to the list of files for flake8 to ignore.