### PR TITLE
Fix database timeout issue during NYT data population

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -57,7 +57,9 @@ Session = sqlalchemy.orm.sessionmaker(
 )
 db = Session()
 
-crud.seed(db)
+# crud.seed(db)
+nyt_records = crud.load_all_nyt_data()
+crud.populate_nyt_data(nyt_records, db)
 
 # db.close()
 

--- a/frontend/src/routes/Consent/index.js
+++ b/frontend/src/routes/Consent/index.js
@@ -7,10 +7,7 @@ export default function MyStory(props) {
   return (
     <>
       <div className={styles.myStory}>
-        <h1 className="title">
-          We will put your story on the map, would you like to provide us more
-          information about yourself?
-        </h1>
+        <h1 className="title">PUT YOUR STORY ON THE MAP</h1>
         <div className={styles.btnGroup}>
           <Fab
             style={{ background: "#0559FD", color: "white" }}

--- a/frontend/yarn-error.log
+++ b/frontend/yarn-error.log
@@ -8,27 +8,26 @@ Yarn version:
   1.22.4
 
 Node version: 
-  12.16.3
+  12.18.1
 
 Platform: 
   linux x64
 
 Trace: 
-  Error: https://registry.yarnpkg.com/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz: Request failed "502 Bad Gateway"
-      at ResponseError.ExtendableBuiltin (/opt/yarn-v1.22.4/lib/cli.js:696:66)
-      at new ResponseError (/opt/yarn-v1.22.4/lib/cli.js:802:124)
-      at Request.<anonymous> (/opt/yarn-v1.22.4/lib/cli.js:67057:16)
-      at Request.emit (events.js:310:20)
-      at Request.module.exports.Request.onRequestResponse (/opt/yarn-v1.22.4/lib/cli.js:141625:10)
-      at ClientRequest.emit (events.js:310:20)
-      at HTTPParser.parserOnIncomingClient [as onIncoming] (_http_client.js:596:27)
-      at HTTPParser.parserOnHeadersComplete (_http_common.js:119:17)
-      at TLSSocket.socketOnData (_http_client.js:469:22)
-      at TLSSocket.emit (events.js:310:20)
+  Error: https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.9.1.tgz: ESOCKETTIMEDOUT
+      at ClientRequest.<anonymous> (/opt/yarn-v1.22.4/lib/cli.js:141375:19)
+      at Object.onceWrapper (events.js:421:28)
+      at ClientRequest.emit (events.js:315:20)
+      at TLSSocket.emitRequestTimeout (_http_client.js:709:9)
+      at Object.onceWrapper (events.js:421:28)
+      at TLSSocket.emit (events.js:327:22)
+      at TLSSocket.Socket._onTimeout (net.js:481:8)
+      at listOnTimeout (internal/timers.js:549:17)
+      at processTimers (internal/timers.js:492:7)
 
 npm manifest: 
   {
-    "name": "frontend",
+    "name": "oasis",
     "version": "0.1.0",
     "private": true,
     "dependencies": {
@@ -41,18 +40,19 @@ npm manifest:
       "@testing-library/jest-dom": "^4.2.4",
       "@testing-library/react": "^9.3.2",
       "@testing-library/user-event": "^7.1.2",
-      "axios": "^0.19.2",
       "chroma-js": "^2.1.0",
       "classnames": "^2.2.6",
       "mapbox-gl": "^1.10.0",
       "moment": "^2.24.0",
       "react": "^16.13.1",
       "react-dom": "^16.13.1",
+      "react-facebook-login": "^4.1.1",
+      "react-google-login": "^5.1.21",
       "react-redux": "^7.2.0",
       "react-router-dom": "^5.1.2",
       "react-scripts": "3.4.1",
       "redux": "^4.0.5",
-      "redux-persist": "^6.0.0",
+      "redux-logger": "^3.0.6",
       "redux-thunk": "^2.3.0"
     },
     "scripts": {
@@ -2331,13 +2331,6 @@ Lockfile:
     resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
     integrity sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
   
-  axios@^0.19.2:
-    version "0.19.2"
-    resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
-    integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
-    dependencies:
-      follow-redirects "1.5.10"
-  
   axobject-query@^2.0.2:
     version "2.1.2"
     resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.1.2.tgz#2bdffc0371e643e5f03ba99065d5179b9ca79799"
@@ -2556,9 +2549,9 @@ Lockfile:
     integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
   
   bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
-    version "4.11.8"
-    resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
-    integrity sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==
+    version "4.11.9"
+    resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.9.tgz#26d556829458f9d1e81fc48952493d0ba3507828"
+    integrity sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==
   
   body-parser@1.19.0:
     version "1.19.0"
@@ -3708,13 +3701,6 @@ Lockfile:
     dependencies:
       ms "2.0.0"
   
-  debug@=3.1.0:
-    version "3.1.0"
-    resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-    integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-    dependencies:
-      ms "2.0.0"
-  
   debug@^3.0.0, debug@^3.1.1, debug@^3.2.5:
     version "3.2.6"
     resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
@@ -3738,6 +3724,11 @@ Lockfile:
     version "0.2.0"
     resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
     integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+  
+  deep-diff@^0.3.5:
+    version "0.3.8"
+    resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.8.tgz#c01de63efb0eec9798801d40c7e0dae25b582c84"
+    integrity sha1-wB3mPvsO7JeYgB1Ax+Da4ltYLIQ=
   
   deep-equal@^1.0.1:
     version "1.1.1"
@@ -4048,9 +4039,9 @@ Lockfile:
     integrity sha512-NK9DBBYEBb5f9D7zXI0hiE941gq3wkBeQmXs1ingigA/jnTg5mhwY2Z5egwA+ZI8OLGKCx0h1Cl8/xeuIBuLlg==
   
   elliptic@^6.0.0:
-    version "6.5.2"
-    resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.2.tgz#05c5678d7173c049d8ca433552224a495d0e3762"
-    integrity sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==
+    version "6.5.3"
+    resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
+    integrity sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==
     dependencies:
       bn.js "^4.4.0"
       brorand "^1.0.1"
@@ -4782,13 +4773,6 @@ Lockfile:
     dependencies:
       inherits "^2.0.3"
       readable-stream "^2.3.6"
-  
-  follow-redirects@1.5.10:
-    version "1.5.10"
-    resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
-    integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
-    dependencies:
-      debug "=3.1.0"
   
   follow-redirects@^1.0.0:
     version "1.10.0"
@@ -8791,7 +8775,7 @@ Lockfile:
       kleur "^3.0.3"
       sisteransi "^1.0.4"
   
-  prop-types@^15.6.2, prop-types@^15.7.2:
+  prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
     version "15.7.2"
     resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
     integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -9012,6 +8996,19 @@ Lockfile:
     resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.7.tgz#1dcfb459ab671d53f660a991513cb2f0a0553108"
     integrity sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA==
   
+  react-facebook-login@^4.1.1:
+    version "4.1.1"
+    resolved "https://registry.yarnpkg.com/react-facebook-login/-/react-facebook-login-4.1.1.tgz#005121236a6ac0dee02099976fb1a3265f9d633e"
+    integrity sha512-COnHEHlYGTKipz4963safFAK9PaNTcCiXfPXMS/yxo8El+/AJL5ye8kMJf23lKSSGGPgqFQuInskIHVqGqTvSw==
+  
+  react-google-login@^5.1.21:
+    version "5.1.21"
+    resolved "https://registry.yarnpkg.com/react-google-login/-/react-google-login-5.1.21.tgz#3d9edc1c08a0cf602a97d70ca406502b747cb890"
+    integrity sha512-z5LtNOc9FZgrkwnqpnzN/hWqG/Tg5+9gKDz0hIHx82U48TkcXvD3HjhhbAzM5OsyFGRE39GnaC4SdB3mpWGX6A==
+    dependencies:
+      "@types/react" "*"
+      prop-types "^15.6.0"
+  
   react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
     version "16.13.1"
     resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -9230,10 +9227,12 @@ Lockfile:
       indent-string "^4.0.0"
       strip-indent "^3.0.0"
   
-  redux-persist@^6.0.0:
-    version "6.0.0"
-    resolved "https://registry.yarnpkg.com/redux-persist/-/redux-persist-6.0.0.tgz#b4d2972f9859597c130d40d4b146fecdab51b3a8"
-    integrity sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==
+  redux-logger@^3.0.6:
+    version "3.0.6"
+    resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-3.0.6.tgz#f7555966f3098f3c88604c449cf0baf5778274bf"
+    integrity sha1-91VZZvMJjzyIYExEnPC69XeCdL8=
+    dependencies:
+      deep-diff "^0.3.5"
   
   redux-thunk@^2.3.0:
     version "2.3.0"
@@ -11055,9 +11054,9 @@ Lockfile:
       websocket-extensions ">=0.1.1"
   
   websocket-extensions@>=0.1.1:
-    version "0.1.3"
-    resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
-    integrity sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==
+    version "0.1.4"
+    resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
+    integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
   
   whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3, whatwg-encoding@^1.0.5:
     version "1.0.5"


### PR DESCRIPTION
This pull request addresses issue #303 by splitting the loading/parsing of the county data and the actual insertion of the new database rows into two separate functions. It's hard to test locally because I never had the database lock issue, but this should cut down significantly on the amount of time that any of my functions ever hold on to the database lock and should prevent timeouts.

Incidentally, I also noticed that I had fixed #304 in the seeding functions, but that it was still possible for records with null FIPS codes to be introduced in subsequent calls to `update()`. I've patched that as well, so fingers crossed, this PR should be able to close both issues.