### PR TITLE
Bug/326 - Add a check for null FIPS codes at the endpoint

### DIFF
--- a/backend/router/data.py
+++ b/backend/router/data.py
@@ -125,6 +125,7 @@ def fetch_county_data(db: Session = Depends(get_db)):
             "scope": DataScope.ADM2,
         }
         for record in result
+        if record.fips is not None
     ]
 
     confirmed_df = pd.DataFrame(confirmed)

--- a/backend/tests/test_nyt_county.py
+++ b/backend/tests/test_nyt_county.py
@@ -57,6 +57,16 @@ def test_async_update(setup):
     assert max_date == today.day or max_date == yesterday.day
 
 
+def test_no_na_fips(setup):
+    """
+    This function checks that no FIPS entries are NA
+    """
+    data = json.loads(setup["app"].get("/api/data/all").content)
+    county_data = data["data"]["adm2"]
+    for county in county_data:
+        assert type(county["fips"]) == str
+
+
 # For the old NYT API - probably don't want to use
 '''
 def test_empty_query(setup):


### PR DESCRIPTION
This pull request address #326 by adding an additional check for FIPS fields that are `null` in the county-level data. It also adds a new unit test to make sure that the endpoints never return a county record with a `null` fips code.