### PR TITLE
Fix KeyError crash when world api returns JSON with error

### DIFF
--- a/backend/router/data.py
+++ b/backend/router/data.py
@@ -46,7 +46,7 @@ class DataScope:
 def fetch_world_data():
     try:
         r = requests.get(url=COVID_WORLD_API_URL)
-    except requests.exceptions.RequestException as e:
+    except (requests.exceptions.RequestException, KeyError) as e:
         print("WARNING: Unable to receive data from api.covid19api.com")
         print(e)
         print("Continuing without it...")


### PR DESCRIPTION
This address #341 for cases when the world API does return a valid JSON response to indicate an error and doesn't actually contain any data. This section of the code now handles both bad responses or no responses using `requests` exceptions as well as valid responses that contain error messages.