### PR TITLE
user trend endpoint

### DIFF
--- a/backend/router/users.py
+++ b/backend/router/users.py
@@ -28,3 +28,8 @@ async def read_users_me(
 @router.get("/count/")
 def get_user_count(db: Session = Depends(get_db)):
     return crud.get_user_count(db)
+
+
+@router.get("/trend/")
+def get_user_trend(db: Session = Depends(get_db)):
+    return crud.get_user_trend(db)


### PR DESCRIPTION
new endpoint at `api/users/trend/`

Return a list of 6 elements that represent counts of newly registered users in current month and past 5 months.

[cur_month-0, cur_month-1, ..., cur_month-5]